### PR TITLE
add instructions to export NPM_AUTH_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Read the [instructions for contributing](./.github/CONTRIBUTING.md).
 
 1. Clone the repository.
 
-2. Run the setup tasks:
+2. Get your `NPM_AUTH_TOKEN` from https://npm.com and `export` it in your shell.
+
+3. Run the setup tasks:
 
         $ npm install
         $ npm test


### PR DESCRIPTION
Fixes #4.

Adds documentation about `export`ing `NPM_AUTH_TOKEN` when using the repo directly.
