### PR TITLE
Warn when project not found

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
 var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
 
 var clubhouseStoryToGithubIssue = exports.clubhouseStoryToGithubIssue = function () {
-  var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(clubhouseStoryURL, githubRepoURL) {
+  var _ref = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee(clubhouseStoryURL, githubRepoURL) {
     var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
     var _parseClubhouseStoryU, storyId, _parseGithubRepoURL, owner, repo, clubhouseUsers, clubhouseUsersById, story, unsavedIssue, unsavedIssueComments, issue;
@@ -71,10 +71,10 @@ var clubhouseStoryToGithubIssue = exports.clubhouseStoryToGithubIssue = function
 }();
 
 var githubIssueToClubhouseStory = exports.githubIssueToClubhouseStory = function () {
-  var _ref2 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2(githubIssueURL, clubhouseProject) {
+  var _ref2 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee2(githubIssueURL, clubhouseProject) {
     var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
-    var users, authorId, projects, _projects$find, projectId, _parseGithubIssueURL, owner, repo, issueNumber, issue, issueComments, unsavedStory, story;
+    var users, authorId, projects, project, projectId, _parseGithubIssueURL, owner, repo, issueNumber, issue, issueComments, unsavedStory, story;
 
     return _regenerator2.default.wrap(function _callee2$(_context2) {
       while (1) {
@@ -94,25 +94,35 @@ var githubIssueToClubhouseStory = exports.githubIssueToClubhouseStory = function
 
           case 8:
             projects = _context2.sent;
-            _projects$find = projects.find(function (project) {
+            project = projects.find(function (project) {
               return project.name === clubhouseProject;
-            }), projectId = _projects$find.id;
+            });
+
+            if (project) {
+              _context2.next = 12;
+              break;
+            }
+
+            throw new Error('The \'' + clubhouseProject + '\' project wasn\'t found in your Clubhouse');
+
+          case 12:
+            projectId = project.id;
             _parseGithubIssueURL = (0, _urlParse.parseGithubIssueURL)(githubIssueURL), owner = _parseGithubIssueURL.owner, repo = _parseGithubIssueURL.repo, issueNumber = _parseGithubIssueURL.issueNumber;
-            _context2.next = 13;
+            _context2.next = 16;
             return (0, _gitHub.getIssue)(options.githubToken, owner, repo, issueNumber);
 
-          case 13:
+          case 16:
             issue = _context2.sent;
-            _context2.next = 16;
+            _context2.next = 19;
             return (0, _gitHub.getCommentsForIssue)(options.githubToken, owner, repo, issueNumber);
 
-          case 16:
+          case 19:
             issueComments = _context2.sent;
             unsavedStory = _issueToStory(authorId, projectId, issue, issueComments);
             story = (0, _clubhouse.createStory)(options.clubhouseToken, unsavedStory);
             return _context2.abrupt('return', story);
 
-          case 20:
+          case 23:
           case 'end':
             return _context2.stop();
         }

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,13 @@ export async function githubIssueToClubhouseStory(githubIssueURL, clubhouseProje
   const {id: authorId} = users[0]
 
   const projects = await listProjects(options.clubhouseToken)
-  const {id: projectId} = projects.find(project => project.name === clubhouseProject)
+  const project = projects.find(project => project.name === clubhouseProject)
+
+  if (!project) {
+    throw new Error(`The '${clubhouseProject}' project wasn't found in your Clubhouse`)
+  }
+
+  const {id: projectId} = project
 
   const {owner, repo, issueNumber} = parseGithubIssueURL(githubIssueURL)
   const issue = await getIssue(options.githubToken, owner, repo, issueNumber)


### PR DESCRIPTION
When the user gives a non-existent project, the library will throw an
error with:

    TypeError: Cannot read property 'id' of undefined

which doesn't give the caller much information about the real
issue. After this commit, that case will instead throw:

    Error: The 'tcrawley' project wasn't found in your Clubhouse
